### PR TITLE
update format of ingress to up-to-date K8s schema (version 1.22), fix blank page

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "teamcity.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -34,8 +36,11 @@ spec:
           {{- range .paths }}
           - path: {{ . }}
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            pathType: Prefix
           {{- end }}
     {{- end }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -41,7 +41,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: chart-example.local
-      paths: []
+      paths: ["/"]
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:


### PR DESCRIPTION
```
Error: Unable to build Kubernetes objects from release manifest: Resource mapping not found for name: "irw-teamcity-release" namespace: "" from "".
No matches for kind "Ingress" in version "networking.k8s.io/v1beta1".
Ensure CRDs (Custom Resource Definitions) are installed first.
```
https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122
https://github.com/codaglobal/teamcity_helm/blob/main/templates/ingress.yaml#L5C13-L5C38

I've updated format of Ingress, and also fixes issues with a blank page after deployment (web resources not being loaded)